### PR TITLE
Add xtrc attribute to index-data for debug purposes

### DIFF
--- a/com.antennahouse.pdf5.ml/xsl/dita2fo_index.xsl
+++ b/com.antennahouse.pdf5.ml/xsl/dita2fo_index.xsl
@@ -290,7 +290,7 @@ E-mail : info@antennahouse.com
                     <xsl:attribute name="significance">
                         <xsl:value-of select="'normal'"/>
                     </xsl:attribute>
-                    <xsl:copy-of select="@xtrf"/>
+                    <xsl:copy-of select="@xtrf,@xtrc"/>
                     <!-- Sortkey -->
                     <xsl:for-each select="$currentIndexSortKey">
                         <xsl:element name="{$cSortKeyElementName}">
@@ -358,7 +358,7 @@ E-mail : info@antennahouse.com
                     <xsl:attribute name="significance">
                         <xsl:value-of select="'normal'"/>
                     </xsl:attribute>
-                    <xsl:copy-of select="@xtrf"/>
+                    <xsl:copy-of select="@xtrf,@xtrc"/>
                     <!-- Sortkey -->
                     <xsl:for-each select="$currentIndexSortKey">
                         <xsl:element name="{$cSortKeyElementName}">
@@ -410,7 +410,7 @@ E-mail : info@antennahouse.com
                     <xsl:attribute name="significance">
                         <xsl:value-of select="'normal'"/>
                     </xsl:attribute>
-                    <xsl:copy-of select="@xtrf"/>
+                    <xsl:copy-of select="@xtrf,@xtrc"/>
                     <!-- Sortkey -->
                     <xsl:for-each select="$currentIndexSortKey">
                         <xsl:element name="{$cSortKeyElementName}">
@@ -513,7 +513,7 @@ E-mail : info@antennahouse.com
                     <xsl:attribute name="significance">
                         <xsl:value-of select="'normal'"/>
                     </xsl:attribute>
-                    <xsl:copy-of select="@xtrf"/>
+                    <xsl:copy-of select="@xtrf,@xtrc"/>
                     <!-- Sortkey -->
                     <xsl:for-each select="$prmIndexSortKey">
                         <xsl:element name="{$cSortKeyElementName}">
@@ -625,7 +625,7 @@ E-mail : info@antennahouse.com
                     <xsl:attribute name="significance">
                         <xsl:value-of select="'normal'"/>
                     </xsl:attribute>
-                    <xsl:copy-of select="@xtrf"/>
+                    <xsl:copy-of select="@xtrf,@xtrc"/>
                     <!-- Sortkey -->
                     <xsl:for-each select="$prmIndexSortKey">
                         <xsl:element name="{$cSortKeyElementName}">

--- a/com.antennahouse.pdf5.ml/xsl/dita2fo_indexcommon.xsl
+++ b/com.antennahouse.pdf5.ml/xsl/dita2fo_indexcommon.xsl
@@ -546,7 +546,7 @@ E-mail : info@antennahouse.com
     
     <xsl:template match="*" mode="MODE_INDEX_DEBUG">
         <xsl:copy>
-            <xsl:copy-of select="@* except (@xtrf|@id)"/>
+            <xsl:copy-of select="@* except (@xtrf|@xtrc|@id)"/>
             <xsl:apply-templates mode="#current"/>
         </xsl:copy>
     </xsl:template>
@@ -1687,6 +1687,16 @@ E-mail : info@antennahouse.com
     <xsl:function name="ahf:getXtrf" as="xs:string">
         <xsl:param name="prmId" as="xs:string"/>
         <xsl:sequence select="string($indextermSorted/index-data[@id=$prmId]/@xtrf)"/>
+    </xsl:function>
+    
+    <!--    function: Get @xtrc
+            param: prmId
+            return: @xtrc
+            note:none
+    -->
+    <xsl:function name="ahf:getXtrc" as="xs:string">
+        <xsl:param name="prmId" as="xs:string"/>
+        <xsl:sequence select="string($indextermSorted/index-data[@id=$prmId]/@xtrc)"/>
     </xsl:function>
     
     <!--    function: Get @seekey

--- a/com.antennahouse.pdf5.ml/xsl/dita2fo_indexi18n.xsl
+++ b/com.antennahouse.pdf5.ml/xsl/dita2fo_indexi18n.xsl
@@ -210,7 +210,7 @@ E-mail : info@antennahouse.com
                     <xsl:attribute name="significance">
                         <xsl:value-of select="'normal'"/>
                     </xsl:attribute>
-                    <xsl:copy-of select="@xtrf"/>
+                    <xsl:copy-of select="@xtrf,@xtrc"/>
                     <!-- indexterm data -->
                     <xsl:copy-of select="$currentIndextermElement"/>
                 </xsl:element>
@@ -255,7 +255,7 @@ E-mail : info@antennahouse.com
                     <xsl:attribute name="significance">
                         <xsl:value-of select="'normal'"/>
                     </xsl:attribute>
-                    <xsl:copy-of select="@xtrf"/>
+                    <xsl:copy-of select="@xtrf,@xtrc"/>
                     <!-- indexterm data -->
                     <xsl:copy-of select="$currentIndextermElement"/>
                 </xsl:element>
@@ -285,7 +285,7 @@ E-mail : info@antennahouse.com
                     <xsl:attribute name="significance">
                         <xsl:value-of select="'normal'"/>
                     </xsl:attribute>
-                    <xsl:copy-of select="@xtrf"/>
+                    <xsl:copy-of select="@xtrf,@xtrc"/>
                     <!-- indexterm data -->
                     <xsl:copy-of select="$currentIndextermElement"/>
                 </xsl:element>
@@ -366,7 +366,7 @@ E-mail : info@antennahouse.com
                     <xsl:attribute name="significance">
                         <xsl:value-of select="'normal'"/>
                     </xsl:attribute>
-                    <xsl:copy-of select="@xtrf"/>
+                    <xsl:copy-of select="@xtrf,@xtrc"/>
                     <!-- indexterm data -->
                     <xsl:copy-of select="$prmIndextermElem"/>
                     <!-- index-see FO data -->
@@ -454,7 +454,7 @@ E-mail : info@antennahouse.com
                     <xsl:attribute name="significance">
                         <xsl:value-of select="'normal'"/>
                     </xsl:attribute>
-                    <xsl:copy-of select="@xtrf"/>
+                    <xsl:copy-of select="@xtrf,@xtrc"/>
                     <!-- indexterm data -->
                     <xsl:copy-of select="$prmIndextermElem"/>
                     <!-- index-see-also FO -->


### PR DESCRIPTION
I've been playing with the index collation routines, and trying to use some of the metadata on `<index-data>` for debug purposes.

Currently, it preserves `@xtrf` from the original index term, which gives you the source file name. It doesn't save `@xtrc`, which provides the location of that element within the file. My index test cases have a couple hundred entries in a single topic, so having the ability to trace the full debug information (file + element location) is helpful. It's also helpful when trying to modify the PDF5 index sort for use elsewhere, because it gives me a precise way to connect the `<index-data>` with the original term.

I thought this might be of interest for the main PDF5 code. I know the mode MODE_INDEX_DEBUG strips out `@xtrf` so in this pull request I had it strip out `@xtrc` as well. The `getXtrc` function is added to match the existing `getXtrf` but I'm not sure it's necessary, as `getXtrf` is only referenced from commented code.