### PR TITLE
Fix #172

### DIFF
--- a/com.antennahouse.pdf5.ml/build.xml
+++ b/com.antennahouse.pdf5.ml/build.xml
@@ -188,6 +188,7 @@
     </condition>
 
     <!-- Make URL for input directory -->
+    <dirname property="user.input.dir" file="${args.input}"/>
     <makeurl property="user.input.dir.url" file="${user.input.dir}"/>
     
     <!-- Make URL for output directory -->

--- a/com.antennahouse.pdf5.ml/build.xml
+++ b/com.antennahouse.pdf5.ml/build.xml
@@ -51,7 +51,7 @@
     
     <!-- XML catalog -->
     <xmlcatalog id="dita.catalog">
-        <catalogpath path="${dita.dir}/catalog-dita.xml"/>
+        <catalogpath path="${dita.dir}${file.separator}plugins${file.separator}org.dita.base${file.separator}catalog-dita.xml"/>
     </xmlcatalog>
     
     <!-- Logical check -->

--- a/com.antennahouse.pdf5.ml/plugin.xml
+++ b/com.antennahouse.pdf5.ml/plugin.xml
@@ -146,6 +146,8 @@
       <val default="true">yes</val>
       <val>no</val>
     </param>
+    <param name="ahf.dir" desc="Specifies AH Formatter directory" type="string"/>
+    <param name="ahf.opt" desc="Specifies AH Formatter option setting file" type="file"/>
   </transtype>
   <template file="build_transform_template.xml"/>
   <template file="xsl/dita2fo_shell_template.xsl"/>


### PR DESCRIPTION
Sometimes referencing `[DITA-OT]/catalog-dita.xml` does not resolve catalog file correctly in `ant` or `dita` command build but not in `Oxygen transformation scenario`.
Change catalog reference to `[DITA-OT]/plugins/org.dita.base/catalog-dita.xml` directly. 