### PR TITLE
change required-cleanup processing

### DIFF
--- a/com.antennahouse.pdf5.ml/xsl/dita2fo_dita_class.xsl
+++ b/com.antennahouse.pdf5.ml/xsl/dita2fo_dita_class.xsl
@@ -47,11 +47,11 @@
     </xsl:function>
 
     <!-- Ignorable elements that is pointed from xref 
+     note:		if pOutputRequiredCleanup is true(), then except it
      -->
     <xsl:variable name="ignorebleElementClasses" as="xs:string+" select="
         (
         'topic/draft-comment',
-        'topic/required-cleanup',
         'topic/related-links',
         'topic/link',
         'topic/linktext',
@@ -65,14 +65,15 @@
         'topic/foreign',
         'topic/unknown',
         'topic/fn',
-        'topic/xref'
+        'topic/xref',
+        if (not($pOutputRequiredCleanup)) then ('topic/required-cleanup') else ()
         )"/>
-    
+  
     <!-- 
      function:  Return $prmElem/@class has value in $ignorebleElementClasses
      param:     $prmElem
      return:    xs:boolean
-     note:		
+     note:		if pOutputRequiredCleanup is true(), then except it
      -->
     <xsl:function name="ahf:isIgnorebleElement" as="xs:boolean">
         <xsl:param name="prmElem" as="element()"/>

--- a/com.antennahouse.pdf5.ml/xsl/dita2fo_text_mode.xsl
+++ b/com.antennahouse.pdf5.ml/xsl/dita2fo_text_mode.xsl
@@ -111,8 +111,23 @@
     
     <!-- indexterm is coded in dita2fo_indexcommon.xsl -->
     
-    <!-- required-cleanup -->
-    <xsl:template match="*[contains-token(@class, 'topic/required-cleanup')]" mode="TEXT_ONLY"/>
+    <!-- required-cleanup 
+    note: if pOutputRequiredCleanup is true(), then retain  its text
+    -->
+    <xsl:template match="*[contains-token(@class, 'topic/required-cleanup')]" mode="TEXT_ONLY">
+        <xsl:choose>
+            <xsl:when test="$pOutputRequiredCleanup">
+                <xsl:value-of select="$requiredCleanupTitlePrefix"/>
+                <xsl:if test="string(@remap)">
+                    <xsl:value-of select="$requiredCleanupRemap"/>
+                    <xsl:value-of select="@remap"/>
+                </xsl:if>
+                <xsl:value-of select="$requiredCleanupTitleSuffix"/>
+                <xsl:apply-templates mode="#current"/>
+            </xsl:when>
+            <xsl:otherwise/>
+        </xsl:choose>
+    </xsl:template>
     
     <!-- state -->
     <xsl:template match="*[contains-token(@class, 'topic/state')]" mode="TEXT_ONLY">


### PR DESCRIPTION
## context

output.required.cleanup is applied only main-text processing (heading, sentences, and so on);
being ignored at navigation(for example TOC or bookmarks)

## changes

Change behaviors TEXT_ONLY and ignorableElementClasses to show required-cleanup contents 
when `$pOutputRequiredCleanup` is `true()`.